### PR TITLE
Add CIFAR10 CNN example

### DIFF
--- a/cifar10_convnet.ipynb
+++ b/cifar10_convnet.ipynb
@@ -1,0 +1,101 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": "# CIFAR10 CNN with TensorFlow\nThis notebook demonstrates building and training a convolutional neural network on the CIFAR10 dataset using TensorFlow 2."
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": "import tensorflow as tf\nfrom tensorflow.keras.datasets import cifar10\nfrom tensorflow.keras.utils import to_categorical\nimport matplotlib.pyplot as plt\nimport numpy as np"
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": "## Load and preprocess data"
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": "(x_train, y_train), (x_test, y_test) = cifar10.load_data()\nx_train = x_train.astype('float32') / 255.0\nx_test = x_test.astype('float32') / 255.0\ny_train = to_categorical(y_train, 10)\ny_test = to_categorical(y_test, 10)"
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": "## Create datasets"
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": "batch_size = 64\ntrain_ds = tf.data.Dataset.from_tensor_slices((x_train, y_train)).shuffle(50000).batch(batch_size)\ntest_ds = tf.data.Dataset.from_tensor_slices((x_test, y_test)).batch(batch_size)"
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": "## Build model"
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": "model = tf.keras.models.Sequential([\n    tf.keras.layers.Conv2D(32,(3,3),activation='relu',padding='same',input_shape=(32,32,3)),\n    tf.keras.layers.Conv2D(32,(3,3),activation='relu',padding='same'),\n    tf.keras.layers.MaxPooling2D(),\n    tf.keras.layers.Dropout(0.25),\n    tf.keras.layers.Conv2D(64,(3,3),activation='relu',padding='same'),\n    tf.keras.layers.Conv2D(64,(3,3),activation='relu',padding='same'),\n    tf.keras.layers.MaxPooling2D(),\n    tf.keras.layers.Dropout(0.25),\n    tf.keras.layers.Flatten(),\n    tf.keras.layers.Dense(512,activation='relu'),\n    tf.keras.layers.Dropout(0.5),\n    tf.keras.layers.Dense(10,activation='softmax')\n])\nmodel.compile(optimizer='adam',loss='categorical_crossentropy',metrics=['accuracy'])"
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": "## Train model"
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": "history = model.fit(train_ds,epochs=20,validation_data=test_ds)"
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": "## Evaluate"
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": "test_loss,test_acc = model.evaluate(test_ds)\nprint('Test accuracy:', test_acc)"
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": "## Visualize some predictions"
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": "class_names=['airplane','automobile','bird','cat','deer','dog','frog','horse','ship','truck']\nimages=x_test[:10]\nlabels=y_test[:10]\npreds=model.predict(images).argmax(axis=1)\nplt.figure(figsize=(10,4))\nfor i in range(10):\n    plt.subplot(2,5,i+1)\n    plt.imshow(images[i])\n    plt.title(class_names[preds[i]])\n    plt.axis('off')\nplt.tight_layout()\nplt.show()"
+    }
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": "Python 3",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "name": "python",
+      "version": "3.8"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- add a Jupyter notebook `cifar10_convnet.ipynb` demonstrating how to build and train a convolutional neural network on CIFAR10 using TensorFlow

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688271f5fbf883328193002c83c5a16c