### PR TITLE
Improve CIFAR10 convnet training

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,12 +7,14 @@ This repository demonstrates small projects using neural networks for working wi
 - `Basket.py` – basketball score prediction with textual features.
 - `Texts_processing.py` – sentiment classification for reviews.
 - `preprocess.py` – helper utilities used in tests.
+- `cifar10_convnet.py` – convolutional network for CIFAR-10 images.
 
 ## Usage
 Install requirements (TensorFlow, pandas, scikit-learn, etc.) and run any script with Python 3:
 
 ```bash
 python3 Lukoil.py
+python3 cifar10_convnet.py
 ```
 
 Datasets are downloaded automatically via `gdown`.


### PR DESCRIPTION
## Summary
- augment CIFAR10 data with random flip and rotation
- add validation split and use val_ds for training
- normalize after each convolution
- document CIFAR10 convnet usage in README

## Testing
- `pytest -q`
- `python3 cifar10_convnet.py` *(fails: URL fetch failure on https://www.cs.toronto.edu due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_688338d5f8e083328d20f710c3d32be3