### PR TITLE
Fix tests path handling without __file__

### DIFF
--- a/tests/test_cos_model.py
+++ b/tests/test_cos_model.py
@@ -1,7 +1,13 @@
 import os
 import sys
 
-sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+# Support running in environments where ``__file__`` may not be defined, such
+# as interactive notebooks. Fallback to the current working directory in that
+# case so imports from the project still resolve correctly.
+base_dir = os.path.dirname(os.path.dirname(
+    globals().get('__file__', os.getcwd())
+))
+sys.path.insert(0, base_dir)
 from cos_model import CosModel
 
 def test_trainable_variable_count():

--- a/tests/test_preprocess.py
+++ b/tests/test_preprocess.py
@@ -2,7 +2,13 @@ import os
 import sys
 import pytest
 
-sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+# Support execution in interactive environments where ``__file__`` may not be
+# available by default. When absent we fall back to the current working
+# directory to locate the project root.
+base_dir = os.path.dirname(os.path.dirname(
+    globals().get('__file__', os.getcwd())
+))
+sys.path.insert(0, base_dir)
 from preprocess import clean_text
 
 


### PR DESCRIPTION
## Summary
- expand sys.path setup in tests to handle environments where `__file__` is missing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6884fc82caac8332a81de57ec432763b