### PR TITLE
Aggregate segmentation masks to seven classes

### DIFF
--- a/segmentation.py
+++ b/segmentation.py
@@ -63,9 +63,60 @@ gdown.download('https://storage.yandexcloud.net/aiueducation/Content/base/l14/co
 
 IMG_WIDTH = 192               # Ширина картинки
 IMG_HEIGHT = 256             # Высота картинки
-NUM_CLASSES = 16              # Задаем количество классов на изображении
+NUM_CLASSES = 7               # Задаем количество классов на изображении
 TRAIN_DIRECTORY = 'train'     # Название папки с файлами обучающей выборки
 VAL_DIRECTORY = 'val'         # Название папки с файлами проверочной выборки
+
+"""Соберем список классов:"""
+
+FLOOR = (100, 100, 100)         # Пол (серый)
+CEILING = (0, 0, 100)           # Потолок (синий)
+WALL = (0, 100, 0)              # Стена (зеленый)
+COLUMN = (100, 0, 0)            # Колонна (красный)
+APERTURE = (0, 100, 100)        # Проем (темно-бирюзовый)
+DOOR = (100, 0, 100)            # Дверь (бордовый)
+WINDOW = (100, 100, 0)          # Окно (золотой)
+EXTERNAL = (200, 200, 200)      # Внешний мир (светло-серый)
+RAILINGS = (0, 200, 0)          # Перила (светло-зеленый)
+BATTERY = (200, 0, 0)           # Батареи (светло-красный)
+PEOPLE = (0, 200, 200)          # Люди (бирюзовый)
+LADDER = (0, 0, 200)            # Лестница (светло-синий)
+INVENTORY = (200, 0, 200)       # Инвентарь (розовый)
+LAMP = (200, 200, 0)            # Лампа (желтый)
+WIRE = (0, 100, 200)            # Провод (голубой)
+BEAM = (100, 0, 200)            # Балка (фиолетовый)
+
+CLASSES = (
+    ("FLOOR", (FLOOR,)),
+    ("CEILING", (CEILING,)),
+    ("WALL", (WALL,)),
+    ("APERTURE_DOOR_WINDOW", (APERTURE, DOOR, WINDOW)),
+    ("COLUMN_RAILINGS_LADDER", (COLUMN, RAILINGS, LADDER)),
+    ("INVENTORY", (INVENTORY,)),
+    (
+        "LAMP_WIRE_BEAM_EXTERNAL_BATTERY_PEOPLE",
+        (LAMP, WIRE, BEAM, EXTERNAL, BATTERY, PEOPLE),
+    ),
+)
+
+COLOR_TO_CLASS_INDEX = {
+    color: class_index
+    for class_index, (_, colors) in enumerate(CLASSES)
+    for color in colors
+}
+
+
+def map_mask_to_class_indices(mask_image):
+    """Преобразует RGB-маску сегментации в карту индексов новых классов."""
+
+    mask_array = np.array(mask_image, dtype=np.uint8)
+    class_map = np.zeros(mask_array.shape[:2], dtype=np.uint8)
+
+    for color, class_index in COLOR_TO_CLASS_INDEX.items():
+        matches = np.all(mask_array == color, axis=-1)
+        class_map[matches] = class_index
+
+    return class_map
 
 """Загрузим оригинальные изображения:"""
 
@@ -108,9 +159,13 @@ val_segments = [] # Создаем пустой список для хранен
 cur_time = time.time() # Засекаем текущее время
 
 for filename in sorted(os.listdir(TRAIN_DIRECTORY+'/segment')): # Проходим по всем файлам в каталоге по указанному пути
-    # Читаем очередную картинку и добавляем ее в список изображений с указанным target_size
-    train_segments.append(image.load_img(os.path.join(TRAIN_DIRECTORY+'/segment',filename),
-                                       target_size=(IMG_WIDTH, IMG_HEIGHT)))
+    # Читаем очередную картинку и преобразуем ее в карту индексов классов
+    mask_image = image.load_img(
+        os.path.join(TRAIN_DIRECTORY+'/segment', filename),
+        target_size=(IMG_WIDTH, IMG_HEIGHT),
+        color_mode='rgb'
+    )
+    train_segments.append(map_mask_to_class_indices(mask_image))
 
 # Отображаем время загрузки картинок обучающей выборки
 print ('Обучающая выборка загружена. Время загрузки: ', round(time.time() - cur_time, 2), 'c', sep='')
@@ -121,36 +176,19 @@ print ('Количество изображений: ', len(train_segments))
 cur_time = time.time() # Засекаем текущее время
 
 for filename in sorted(os.listdir(VAL_DIRECTORY+'/segment')): # Проходим по всем файлам в каталоге по указанному пути
-    # Читаем очередную картинку и добавляем ее в список изображений с указанным target_size
-    val_segments.append(image.load_img(os.path.join(VAL_DIRECTORY+'/segment',filename),
-                                     target_size=(IMG_WIDTH, IMG_HEIGHT)))
+    # Читаем очередную картинку и преобразуем ее в карту индексов классов
+    mask_image = image.load_img(
+        os.path.join(VAL_DIRECTORY+'/segment', filename),
+        target_size=(IMG_WIDTH, IMG_HEIGHT),
+        color_mode='rgb'
+    )
+    val_segments.append(map_mask_to_class_indices(mask_image))
 
 # Отображаем время загрузки картинок проверочной выборки
 print ('Проверочная выборка загружена. Время загрузки: ', round(time.time() - cur_time, 2), 'c', sep='')
 
 # Отображаем количество элементов в проверочном наборе сегментированных изображений
 print ('Количество изображений: ', len(val_segments))
-
-"""Соберем список классов:"""
-
-FLOOR = (100, 100, 100)         # Пол (серый)
-CEILING = (0, 0, 100)           # Потолок (синий)
-WALL = (0, 100, 0)              # Стена (зеленый)
-COLUMN = (100, 0, 0)            # Колонна (красный)
-APERTURE = (0, 100, 100)        # Проем (темно-бирюзовый)
-DOOR = (100, 0, 100)            # Дверь (бордовый)
-WINDOW = (100, 100, 0)          # Окно (золотой)
-EXTERNAL = (200, 200, 200)      # Внешний мир (светло-серый)
-RAILINGS = (0, 200, 0)          # Перила (светло-зеленый)
-BATTERY = (200, 0, 0)           # Батареи (светло-красный)
-PEOPLE = (0, 200, 200)          # Люди (бирюзовый)
-LADDER = (0, 0, 200)            # Лестница (светло-синий)
-INVENTORY = (200, 0, 200)       # Инвентарь (розовый)
-LAMP = (200, 200, 0)            # Лампа (желтый)
-WIRE = (0, 100, 200)            # Провод (голубой)
-BEAM = (100, 0, 200)            # Балка (фиолетовый)
-
-CLASSES = (FLOOR, CEILING, WALL, COLUMN, APERTURE, DOOR, WINDOW, EXTERNAL, RAILINGS, BATTERY, PEOPLE, LADDER, INVENTORY, LAMP, WIRE, BEAM)
 
 """# Решение"""
 


### PR DESCRIPTION
## Summary
- regroup the 16 segmentation colors into seven semantic class groups and expose a color-to-class index mapping
- convert loaded training and validation masks to the new class indices so they are encoded from 0 to 6

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dd7d996e448332aedd6b0072c4322c